### PR TITLE
Move metaprogramming to explicit attributes

### DIFF
--- a/recurring_ical_events.py
+++ b/recurring_ical_events.py
@@ -10,6 +10,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
+"""Calculate repetitions of icalendar components.
+"""
 import icalendar
 import datetime
 import pytz
@@ -23,37 +25,53 @@ from typing import Optional
 import re
 import functools
 
-class RecurringIcalEventsError(Exception):
-    """Base exception for errors of recurring-ical-events library"""
 
-    default_message = "An error occurred during recurring iCal events process."
+class InvalidCalendar(ValueError):
+    """Exception thrown for bad icalendar content."""
 
-    def __init__(self, *args, **kwargs):
-        for kwarg, kwarg_val in kwargs.items():
-            setattr(self, kwarg, kwarg_val)
-        
-        if not hasattr(self, "message"):
-            if args and isinstance(args[0], str):
-                self.message = args[0]
-            else:
-                self.message = self.default_message
-
-        self.message = self.message.format(**kwargs)
+    def __init__(self, message:str):
+        """Create a new error with a message."""
+        self._message = message
         super().__init__(self.message)
 
+    @property
+    def message(self) -> str:
+        """The error message."""
+        return self._message
 
-class PeriodEndBeforeStart(RecurringIcalEventsError):
-    """An end date start before a start date"""
-    
-    default_message = "The period end date {end} is before period start date {start}"
 
-class BadRuleStringFormat(RecurringIcalEventsError):
-    """An iCal rule string is badly formatted"""
-    default_message = 'Bad rule string format. {detail}\n"{rule_string}"'
+class PeriodEndBeforeStart(InvalidCalendar):
+    """An event or component starts before it ends."""
 
-class UnsupportedComponent(RecurringIcalEventsError):
-    """This error is raised when a component is not supported, yet."""
+    def __init__(self, message, start, end):
+        """Create a new PeriodEndBeforeStart error."""
+        super().__init__(message)
+        self._start = start
+        self._end = end
 
+    @property
+    def start(self):
+        """The start of the component's period."""
+        return self._start
+
+    @property
+    def end(self):
+        """The end of the component's period."""
+        return self._end
+
+
+class BadRuleStringFormat(InvalidCalendar):
+    """An iCal rule string is badly formatted."""
+
+    def __init__(self, message:str, rule:str):
+        """Create an error with a bad rule string."""
+        super().__init__(message + ": " + rule)
+        self._rule = rule
+
+    @property
+    def rule(self) -> str:
+        """The malformed rule string"""
+        return self._rule
 
 
 if sys.version_info[0] == 2:
@@ -109,15 +127,17 @@ def time_span_contains_event(span_start, span_stop, event_start, event_stop, com
 
     This is an essential function of the module. It should be tested in
     test/test_time_span_contains_event.py.
+
+    This raises a PeriodEndBeforeStart exception if a start is after an end.
     """
     if not comparable:
         span_start, span_stop, event_start, event_stop = make_comparable((
             span_start, span_stop, event_start, event_stop
         ))
     if event_start > event_stop:
-        raise PeriodEndBeforeStart("the event must start before it ends (start: {start} end: {end})", start=event_start, end=event_stop)
+        raise PeriodEndBeforeStart(f"the event must start before it ends (start: {event_start} end: {event_stop})", event_start, event_stop)
     if span_start > span_stop:
-        raise PeriodEndBeforeStart("the time span must start before it ends (start: {start} end: {end})", start=span_start, end=span_stop)
+        raise PeriodEndBeforeStart(f"the time span must start before it ends (start: {span_start} end: {span_stop})", span_start, span_stop)
     if event_start == event_stop:
         if span_start == span_stop:
             return event_start == span_start
@@ -211,6 +231,7 @@ class Repetition:
         """Debug representation with more info."""
         return "{}({{'UID':{}...}}, {}, {})".format(self.__class__.__name__, self.source.get("UID"), self.start, self.stop)
 
+
 class RepeatedComponent:
     """Base class for RepeatedEvent, RepeatedJournal and RepeatedTodo"""
 
@@ -259,7 +280,7 @@ class RepeatedComponent:
                     if _rule not in _dedup_rules:
                         _dedup_rules.append(_rule)
                 _component_rules = _dedup_rules
-    
+
             for _rule in _component_rules:
                 rrule = self.create_rule_with_start(_rule.to_ical().decode())
                 self.rule.rrule(rrule)
@@ -270,7 +291,7 @@ class RepeatedComponent:
             self.rule.exdate(exdate)
         for rdate in self.rdates:
             self.rule.rdate(rdate)
-        
+
         if not self.until or not compare_greater(self.start, self.until):
             self.rule.rdate(self.start)
 
@@ -287,7 +308,7 @@ class RepeatedComponent:
             # ValueError: RRULE UNTIL values must be specified in UTC when DTSTART is timezone-aware
             rule_list = rule_string.split(";UNTIL=")
             if len(rule_list) != 2:
-                raise BadRuleStringFormat(detail="UNTIL parameter is missing", rule_string=rule_string) from None
+                raise BadRuleStringFormat("UNTIL parameter is missing", rule_string) from None
             date_end_index = rule_list[1].find(";")
             if date_end_index == -1:
                 date_end_index = len(rule_list[1])
@@ -302,7 +323,7 @@ class RepeatedComponent:
                 if len(until_string) == 8:
                     until_string += "T000000"
                 if len(until_string) != 15:
-                    raise BadRuleStringFormat(detail="UNTIL parameter bad format", rule_string=rule_string) from None
+                    raise BadRuleStringFormat("UNTIL parameter has a bad format", rule_string) from None
                 until_string += "Z" # https://stackoverflow.com/a/49991809
             new_rule_string = rule_list[0] + rule_list[1][date_end_index:] + ";UNTIL=" + until_string
             return self.rrulestr(new_rule_string)
@@ -327,7 +348,7 @@ class RepeatedComponent:
         if len(rule_list) == 1:
             return None
         if len(rule_list) != 2:
-            raise BadRuleStringFormat(detail="There should be only one UNTIL", rule_string=rrule)
+            raise BadRuleStringFormat("There should be only one UNTIL", rrule)
         date_end_index = rule_list[1].find(";")
         if date_end_index == -1:
             date_end_index = len(rule_list[1])
@@ -512,7 +533,13 @@ DATE_MAX = (2038, 1, 1)
 DATE_MAX_DT = datetime.date(*DATE_MAX)
 
 class UnfoldableCalendar:
-    '''A calendar that can unfold its events at a certain time.'''
+    '''A calendar that can unfold its events at a certain time.
+
+    Functions like at(), between() and after() can be used to query the
+    selected components. If any malformed icalendar information is found,
+    an InvalidCalendar exception is raised. For other bad arguments, you
+    should expect a ValueError.
+    '''
 
     recurrence_calculators = {
         "VEVENT": RepeatedEvent,
@@ -524,15 +551,13 @@ class UnfoldableCalendar:
         """Create an unfoldable calendar from a given calendar."""
         if calendar.get("CALSCALE", "GREGORIAN") != "GREGORIAN":
             # https://www.kanzaki.com/docs/ical/calscale.html
-            raise RecurringIcalEventsError("Only Gregorian calendars are supported.")
+            raise InvalidCalendar("Only Gregorian calendars are supported.")
 
         self.repetitions = []
         for component_name in components:
             if component_name not in self.recurrence_calculators:
-                raise UnsupportedComponent(
-                    '"{component_name}" is an unknown name for a component. I only know these: {allowed_components}.', 
-                    component_name=component_name, 
-                    allowed_components=', '.join(self.recurrence_calculators)
+                raise ValueError(
+                    f'"{component_name}" is an unknown name for a recurring component. I only know these: {", ".join(self.recurrence_calculators)}.',
                 )
             for event in calendar.walk(component_name):
                 recurrence_calculator = self.recurrence_calculators[component_name]
@@ -582,7 +607,7 @@ class UnfoldableCalendar:
             date = (date,)
         if isinstance(date, str):
             if len(date) != 8 or not date.isdigit():
-                raise RecurringIcalEventsError('format yyyymmdd expected "{date}"', date=date)
+                raise ValueError(f'Format yyyymmdd expected for {repr(date)}.')
             date = (int(date[:4], 10), int(date[4:6], 10), int(date[6:]))
         if isinstance(date, datetime.datetime):
             return self.between(date, date)
@@ -702,7 +727,7 @@ class UnfoldableCalendar:
             earliest_end = next_end
 
 
-def of(a_calendar, keep_recurrence_attributes=False, components=["VEVENT"]):
+def of(a_calendar, keep_recurrence_attributes=False, components=["VEVENT"]) -> UnfoldableCalendar:
     """Unfold recurring events of a_calendar
 
     - a_calendar is an icalendar VCALENDAR component or something like that.
@@ -711,3 +736,9 @@ def of(a_calendar, keep_recurrence_attributes=False, components=["VEVENT"]):
     """
     a_calendar = x_wr_timezone.to_standard(a_calendar)
     return UnfoldableCalendar(a_calendar, keep_recurrence_attributes, components)
+
+
+__all__ = [
+    "of", "InvalidCalendar", "PeriodEndBeforeStart",
+    "BadRuleStringFormat", "is_pytz", "DATE_MIN", "DATE_MAX",
+    "UnfoldableCalendar"]

--- a/test/test_issue_101_select_components.py
+++ b/test/test_issue_101_select_components.py
@@ -4,7 +4,6 @@ By default, it should be events.
 If a component is not supported, an error is raised.
 """
 import pytest
-from recurring_ical_events import UnsupportedComponent
 
 
 @pytest.mark.parametrize("components,count,calendar,message", [
@@ -40,7 +39,7 @@ def test_components_and_their_count(calendars, components, count, calendar, mess
 ])
 def test_unsupported_component_raises_error(component, calendars):
     """If a component is not recognized, we want to inform the user."""
-    with pytest.raises(UnsupportedComponent) as error:
+    with pytest.raises(ValueError) as error:
         calendars.components = [component]
         calendars.rdate
     assert f"\"{component}\"" in str(error)


### PR DESCRIPTION
Hi, I really value your addition and thus, I added my bits to not tell you what to do without doing the work myself! We can discuss this thus a bit more with example code if you wish.

What I did here:

1. I make a distinction: Any bad calendar data leads to an InvalidCalendar exception. Any other wrong user input (component name, date format) is easily corrected and leads to a ValueError. In all cases, the problem is the value of what we get, never the type, hence the ValueError is the base. With this distinction, users who just read calendars know where the problem is. [ValueError](https://gadgetmates.com/value-error-python) vs. InvalidCalendar.
2. I add some documentation. All methods I prefer documented. Since this is my preference, I do not expect you to do that.
3. I removed the meta programming in favour of explicit attributes. This might help debug in the future.
4. I added `__all__` because now that we have more exports than `of()`, I want to be sure that people know what the explicit interface is and what might change in the future more easily. This will be important for https://github.com/niccokunzmann/python-recurring-ical-events/issues/133 as people want to know what to subclass.
5. I added some type hints where known.

I like the error distinction that you made.
I humbly ask to review and maybe merge. I hope that this does not come across as a criticism but rather as an "I like your code and since I will maintain it, I would like to give it my personal touch instead of telling you to do it :)"